### PR TITLE
fix git diff list for files with spaces

### DIFF
--- a/sphinxext/rediraffe.py
+++ b/sphinxext/rediraffe.py
@@ -346,7 +346,7 @@ class CheckRedirectsDiffBuilder(Builder):
         rename_hints = {}
         for line in renamed_files_out:
             line = line.strip()
-            r_perc, rename_from, rename_to = re.split(r"\s+", line)
+            r_perc, rename_from, rename_to = re.split(r"\t", line)
             perc = int(r_perc[1:])
             path_rename_from = abs_path_in_src_dir_w_src_suffix(rename_from)
             path_rename_to = abs_path_in_src_dir_w_src_suffix(rename_to)


### PR DESCRIPTION
git uses \t as delimiter. Without this, split fails with "Too many values to unpack", as `\s+` catches spaces in filenames.

I don't know if there are situations where git would use a different character.

Example git output line:

```python
'R099\tfile name.md\tnew file name.md'
```
